### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ There is not a standard BQ connector for the GCP Healthcare NLP API but it has b
 ```
 [
     {
+       "name": "rawText",
+       "type": "STRING"
+    },
+    {
        "fields": [
          {
            "name": "preferredTerm",


### PR DESCRIPTION
Schema Update: To match the python code

The field "rawText" that exists in the sample python code is missing in the schema 
definition of the table